### PR TITLE
The week id is now correctly passed to Picks::Remaining

### DIFF
--- a/html/includes/runtime/non-admin/JSON/MakePicks.php
+++ b/html/includes/runtime/non-admin/JSON/MakePicks.php
@@ -67,7 +67,7 @@ class JSON_MakePicks extends JSONUserAction
 			}
 		}
 
-		$remaining = $db_picks->Remaining( $this->_auth->getUserID(), $week );
+		$remaining = $db_picks->Remaining( $this->_auth->getUserID(), $week[ 'id' ] );
 
 		return $this->setData( array( 'remaining' => $remaining, 'message' => 'You have picked the <b>' . $winning_team[ 'team' ] . '</b> to beat the <b>' . $losing_team[ 'team' ] . '</b>' ) );
 	}


### PR DESCRIPTION
Fixed and issue introduced in the recent round of blitz commits
where the entire weeek structure was being passed to the Remaining funciton
instead of the week id.  This caused Remaining to always return 0 and display
as such to the user.