### PR TITLE
JSON_LoadWeeklyRecords now only DB errors when List_Load is false

### DIFF
--- a/html/includes/runtime/non-admin/JSON/LoadWeeklyRecords.php
+++ b/html/includes/runtime/non-admin/JSON/LoadWeeklyRecords.php
@@ -14,7 +14,7 @@ class JSON_LoadWeeklyRecords extends JSONUser
 			return $this->setDBError();
 		}
 
-		if ( !$db_weeks->List_Load_Locked( $weeks ) )
+		if ( $db_weeks->List_Load_Locked( $weeks ) === false )
 		{
 			return $this->setDBError();
 		}


### PR DESCRIPTION
This fixes the issue where in the first week no weeks are locked so
it was going into the error case.