### PR TITLE
51: Explicitly defined the _run_update class member

### DIFF
--- a/html/includes/classes/Screen.php
+++ b/html/includes/classes/Screen.php
@@ -147,6 +147,8 @@ class ScreenRenderer
 	private $_jquery_data;
 	private $_content_data;
 
+	private $_run_update;
+
 	public function __construct()
 	{
 		$this->_db 					= new Database();


### PR DESCRIPTION
Fixed an issue where the member was dynamically being defined which is no longer supported in PHP 8+