### PR TITLE
65: Reworked the leaderboard to look more like an official leaderboard

### DIFF
--- a/html/includes/runtime/non-admin/screens/Leaderboard.php
+++ b/html/includes/runtime/non-admin/screens/Leaderboard.php
@@ -5,26 +5,43 @@ class Screen_Leaderboard extends Screen_User
 	public function content()
 	{
 		print "<h1>Leaderboard</h1>\n";
-	
+
 		$count = $this->_Leaderboard( $leaders );
-		
+
 		if ( $count === false )
 		{
 			return $this->setDBError();
 		}
-		
+
 		if ( $count === 0 )
-		{		
+		{
 			print "<p>The leaderboard is currently empty.</p>";
-			
+
 			return true;
 		}
-		
+
+		print( '<table width="100%">' );
+		print( '<tr>' );
+		print( '<th align="left">Place</th><th align="left">Player</th><th align="left">Wins</th><th align="left">Losses</th>' );
+		print( '</tr>' );
+
 		foreach ( $leaders as $leader )
 		{
-			printf( "<p>%s %s - %d Wins - %d Losses</p>\n", Functions::Place( $leader[ 'current_place' ] ), htmlentities( ucwords( $leader[ 'name' ] ) ), $leader[ 'wins' ], $leader[ 'losses' ] );
+			print( '<tr>' );
+
+			if ( $leader[ 'current_place' ] <= 5 )	printf( '<td style="color:green;font-weight:bold;">%s</td>', Functions::Place( $leader[ 'current_place' ] ) );
+			else									printf( '<td>%s</td>', Functions::Place( $leader[ 'current_place' ] ) );
+
+			printf( '<td>%s%s</td>', htmlentities( ucwords( $leader[ 'name' ] ) ), $leader[ 'pw_opt_out' ] ? '*' : '' );
+			printf( '<td>%d</td>', $leader[ 'wins' ] );
+			printf( '<td>%d</td>', $leader[ 'losses' ] );
+			print( '</tr>' );
 		}
-		
+		print( '</table>' );
+
+		print( '<br /><br />' );
+		print( '* Player has opted out of the perfect week pool' );
+
 		return true;
 	}
 


### PR DESCRIPTION
The leaderboard now outputs a specific wins and losses column making it easier to read.  In addition, it indicates players that have opted out of the perfect week pool.  Finally, the players in the top 5 spots (the payout spots) now output their position using green text to indicate they are in the money.