### PR TITLE
Misc. conversion of die/exit calls

### DIFF
--- a/html/json.php
+++ b/html/json.php
@@ -9,4 +9,4 @@ $action			= Functions::Post( 'action' );
 $token			= Functions::Post( 'token' );
 $jsonmanager	= new JSONManager();
 
-die( $jsonmanager->execute( $admin, $action, $token ) );
+$jsonmanager->execute( $admin, $action, $token );

--- a/html/setup.php
+++ b/html/setup.php
@@ -9,11 +9,13 @@ $action	= Functions::Get( 'Action' );
 
 if ( $action === 'INSTALL' )
 {
-	die( install() );
+	install();
+	exit();
 }
 else if ( $action === 'UNINSTALL' )
 {
-	die( uninstall() );
+	uninstall();
+	exit();
 }
 
 die( 'Nothing to see here' );
@@ -25,7 +27,8 @@ function install()
 
 	if ( $setup->Configured() )
 	{
-		die( $setup->Get_Error() );
+		$setup->Get_Error();
+		exit();
 	}
 
 	if ( $install != '' )
@@ -56,7 +59,8 @@ function install()
 
 		if ( !$setup->Install() )
 		{
-			die( $setup->Get_Error() );
+			print( $setup->Get_Error() );
+			exit();
 		}
 
 		if ( !$db_settings->Load( $settings ) )
@@ -77,7 +81,8 @@ function install()
 
 		if ( !$db_weeks->Create_Weeks( $timestamp ) )
 		{
-			die( $db_weeks->Get_Error() );
+			print( $db_weeks->Get_Error() );
+			exit();
 		}
 
 		if ( !$db_games->Create_Games() )


### PR DESCRIPTION
PHP8.4 now outputs a warning if die/exit is called with a null value. A handful of locations were passing null to die calls so those were modified to print the errors and then call exit.